### PR TITLE
Forbid RW assignments for mapped statements

### DIFF
--- a/src/pgo/trans/MPCalPCalCodegenPass.scala
+++ b/src/pgo/trans/MPCalPCalCodegenPass.scala
@@ -199,8 +199,8 @@ object MPCalPCalCodegenPass {
             findRef(lhs).flatMap {
               case ident if mappingsMap.contains(ById(ident.refersTo)) =>
                 val (mappingCount, mapping) = mappingsMap(ById(ident.refersTo))
-                // maybe implement depth > mappingCount in the future, but it may be more confusion than it's worth
-                // for now, assert that it's not the case, to avoid very confusing mis-compilations
+                // this should always be the case; it would be too confusing otherwise, as documented in
+                // test/files/general/pcalgen/MappingMacroRWExpansion.tla
                 assert(mappingCount == findLhsDepth(lhs))
                 val convertedLhs = convertLhs(lhs)
                 val valueBind = PCalVariableDeclarationValue(TLAIdentifier(nameCleaner.cleanName("value")), rhs)

--- a/test/files/general/MPCalKindMatching.tla
+++ b/test/files/general/MPCalKindMatching.tla
@@ -9,7 +9,7 @@ EXTENDS Sequences, FiniteSets, Integers
         l4: call Proc2(ref a[_][_]);
         l5: a[2] := 3;
         l3: (*:: expectedError: MPCalKindMismatchError *) a := 3;
-        l6: a[5][6] := 3;
+        l6: (*:: expectedError: MPCalReadWriteAssignmentForbidden *) a[5][6] := 3;
         l7: x := (*:: expectedError: MPCalKindMismatchError *) a;
         l8: x := a[3];
         l9: x := a[(*:: expectedError: MPCalKindMismatchError *) a];

--- a/test/files/pcalgen/MappingMacroRWExpansion.tla
+++ b/test/files/pcalgen/MappingMacroRWExpansion.tla
@@ -1,0 +1,43 @@
+------------------------------- MODULE func -------------------------------
+
+EXTENDS Naturals, Sequences, TLC, FiniteSets
+
+(********************
+
+--mpcal func {
+
+    mapping macro MP {
+        read {
+            yield $variable;
+        }
+
+        write {
+            yield $value;
+        }
+    }
+
+    archetype ANode(ref arr[_]) {
+    lbl1:
+        (* this has the "wrong" number of indices, and implies:
+            - read arr[1] (call it x)
+            - write [x EXCEPT ![2] = "a"] to arr[1]
+
+          this is hard to keep track of, so it's forbidden instead *)
+        (*:: expectedError: MPCalReadWriteAssignmentForbidden *) arr[1][2] := "a";
+
+    lbl2:
+        print arr[1][2];
+    }
+
+    variable
+        arr = [d1 \in {1} |-> [d2 \in {2} |-> ""]];
+
+    fair process (Node \in {1}) == instance ANode(ref arr[_])
+        mapping arr[_] via MP;
+}
+
+********************)
+
+\* BEGIN TRANSLATION
+
+=============================================================================


### PR DESCRIPTION
See test/files/pcalgen/MappingMacroRWExpansion.tla for context.

Fixes #163 by emitting an appropriate compiler error to the user rather than failing an assert.