### PR TITLE
Allow binding self-alias in MPCal instance arguments

### DIFF
--- a/test/files/pcalgen/MPCalInstanceClauseSelf.tla
+++ b/test/files/pcalgen/MPCalInstanceClauseSelf.tla
@@ -1,0 +1,21 @@
+---- MODULE MPCalInstanceClauseSelf ----
+EXTENDS Sequences, TLC, FiniteSets
+
+(*
+--mpcal MPCalInstanceClauseSelf {
+    archetype Foo(x) {
+        lbl: skip;
+    }
+
+    process (Bar = 42) == instance Foo(Bar);
+}
+
+\* BEGIN PLUSCAL TRANSLATION
+
+\* END PLUSCAL TRANSLATION
+
+*)
+
+\* BEGIN TRANSLATION
+
+====

--- a/test/files/pcalgen/MPCalInstanceClauseSelf.tla.expectpcal
+++ b/test/files/pcalgen/MPCalInstanceClauseSelf.tla.expectpcal
@@ -1,0 +1,31 @@
+---- MODULE MPCalInstanceClauseSelf ----
+EXTENDS Sequences, TLC, FiniteSets
+
+(*
+--mpcal MPCalInstanceClauseSelf {
+    archetype Foo(x) {
+        lbl: skip;
+    }
+
+    process (Bar = 42) == instance Foo(Bar);
+}
+
+\* BEGIN PLUSCAL TRANSLATION
+--algorithm MPCalInstanceClauseSelf {
+  
+  process (Bar = 42)
+    variables x = self;
+  {
+    lbl:
+      skip;
+      goto Done;
+  }
+}
+
+\* END PLUSCAL TRANSLATION
+
+*)
+
+\* BEGIN TRANSLATION
+
+====


### PR DESCRIPTION
Fixes #173.

It is now allowed; the MPCal parser's scoping process and the PCal codegen process have been adapted to reflect this.

A small test is included to make sure it actually works.